### PR TITLE
Get rid of hostgroups in favor of instance_selector expvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,6 @@ And then just restart Grafana, so it reads new configuration.
 List of things we would like to do see in the future versions:
 
   * better error reporting if invalid configuration is passed
-  * discard hostgroups, something similar to
-```
-      rows: section in dashboard will be dictionary of:
-        graph_template: instance_selector_variable_name (from expvars)
-        also push it into graph title somehow...
-        hmm: mapping can enable to templatize expressions as well
-      rows:
-        - graph_template:
-            befe: backend
-        - graph_template:
-            befe: frontend
-       and expression: expression: sum(irate(haproxy_%(befe)s_bytes_out_total{exported_instance=~".*"}[5m])) by (%(befe)s)
-```
   * graph_overrides to dashboard section and maybe something similar to `seriesOverride` as well
 ```
        graph_overrides:

--- a/config.yml.example
+++ b/config.yml.example
@@ -218,7 +218,6 @@ templating:
                 inherits: templating_template
                 metric: node_load1
                 label: exported_instance
-hostgroups: {}
 dashboardLinks:
         template:
                 type: link


### PR DESCRIPTION
Since we introduced templating and we usually need instance_selector
defined explicitly on dashboard level anyway, let's get rid of
hostgroups altogether.

To migrate away from hostgroups, just move the regexps from the
hostgroup definition to expvars named `instance_selector` and then drop
the whole `hostgroups` block from the config file.