### PR TITLE
Report error when templating_regexps is list not dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And then just restart Grafana, so it reads new configuration.
 
 List of things we would like to do see in the future versions:
 
-  * better error reporting if invalid configuration is passed
+  * error reporting if invalid configuration is passed, stack traces are useless
   * graph_overrides to dashboard section and maybe something similar to `seriesOverride` as well
 ```
        graph_overrides:

--- a/generate.py
+++ b/generate.py
@@ -297,6 +297,12 @@ class Template(ConfigObject):
         # defined as an expvar with the same name as the value of the key.
         # This allows overriding the regexp per dashboard.
         if hasattr(parent_dashboard, 'templating_regexps') and \
+                isinstance(parent_dashboard.templating_regexps, list):
+            print("ERROR: templating_regexps must be dict and is list in "
+                  "template %s used in dashboard %s (remove dashes?)" %
+                  (s.name, parent_dashboard.name))
+            sys.exit(1)
+        if hasattr(parent_dashboard, 'templating_regexps') and \
                 s.name in parent_dashboard.templating_regexps:
             result['regex'] = parent_dashboard.expvars[
                 parent_dashboard.templating_regexps[s.name]]


### PR DESCRIPTION
  * when mistakenly set as a list of dicts generating json dashboards
    succeded and were just broken in grafana

    list of dicts is:
    templating_regexps:
    - x: y
    - a: b

    instead of dict:
    templating_regexps:
      x: y
      a: b